### PR TITLE
Fix first LED brightness bug

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ platform_packages =
 ; Chip in use
 board = ATtiny1616
 ; Clock frequency in [Hz]
-board_build.f_cpu = 16000000L
+board_build.f_cpu = 20000000L
 ; Oscillator type (internal or external)
 board_hardware.oscillator = internal
 

--- a/src/blinker.h
+++ b/src/blinker.h
@@ -78,7 +78,7 @@ class LedBlinker {
   void set_bar(uint16_t value) {
     if (value < bar_knee_value_) {
       // the first LED brightness is proportional to 0..bar_knee_value_ V
-      bar_value_[0] = 255 * value / bar_knee_value_;
+      bar_value_[0] = (255L * value ) / bar_knee_value_;
       for (int i = 1; i < NUM_LEDS; i++) {
         bar_value_[i] = 0;
       }

--- a/src/constants.h
+++ b/src/constants.h
@@ -5,7 +5,7 @@
 #define LEGACY_FW_VERSION 0xff
 
 // FW version provided by the new I2C register
-constexpr char kFWVersion[] = {2, 0, 2, 0xff};
+constexpr char kFWVersion[] = {2, 0, 3, 0xff};
 
 // HW version provided by the Legacy version I2C register
 #define LEGACY_HW_VERSION 0x00
@@ -72,7 +72,7 @@ constexpr char kHWVersion[] = {2, 0, 0, 0xff};
 #define GPIO_OFF_TIME_LIMIT 1000
 
 // Vcap voltage at which 5V is enabled
-#define VCAP_POWER_ON 6.0
+#define VCAP_POWER_ON 8.0
 // Vcap voltage at which 5V is disabled
 #define VCAP_POWER_OFF 5.0
 // Vcap voltage should never exceed this value

--- a/src/constants.h
+++ b/src/constants.h
@@ -5,7 +5,7 @@
 #define LEGACY_FW_VERSION 0xff
 
 // FW version provided by the new I2C register
-constexpr char kFWVersion[] = {2, 0, 3, 0xff};
+constexpr char kFWVersion[] = {2, 0, 4, 0xff};
 
 // HW version provided by the Legacy version I2C register
 #define LEGACY_HW_VERSION 0x00


### PR DESCRIPTION
Now the first LED brightness is proportional to the voltage as well.

Firmware version is bumped to 2.0.4.