### PR TITLE
Release 2.0.6; Enable reset functionality and P and E pins

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -5,16 +5,16 @@
 #define LEGACY_FW_VERSION 0xff
 
 // FW version provided by the new I2C register
-constexpr char kFWVersion[] = {2, 0, 5, 0xff};
+constexpr char kFWVersion[] = {2, 0, 6, 0xff};
 
 // HW version provided by the Legacy version I2C register
 #define LEGACY_HW_VERSION 0x00
 
 // HW version provided by the new I2C register
-constexpr char kHWVersion[] = {2, 0, 0, 0xff};
+constexpr char kHWVersion[] = {2, 0, 1, 0xff};
 
 // Needed for HW bug workarounds for version 2.0.0 only
-#define HW_VERSION_2_0_0
+//#define HW_VERSION_2_0_0
 
 // I2C address of the MCU
 #define I2C_ADDRESS 0x6d

--- a/src/globals.h
+++ b/src/globals.h
@@ -51,6 +51,7 @@ extern char temperature_K_buf[2];
 
 extern volatile bool shutdown_requested;
 extern volatile bool sleep_requested;
+extern volatile bool reset_requested;
 
 extern LedBlinker led_blinker;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@ LedBlinker led_blinker(led_pins, off_pattern, led_bar_knee_value);
 
 volatile bool shutdown_requested = false;
 volatile bool sleep_requested = false;
+volatile bool reset_requested = false;
 
 bool rtc_wakeup_triggered = false;
 bool ext_wakeup_triggered = false;
@@ -186,6 +187,11 @@ void loop() {
     // if POWER_TOGGLE_PIN is pulled low, initiate shutdown
     if (read_pin(POWER_TOGGLE_PIN) == false) {
       shutdown_requested = true;
+    }
+
+    // Pulling both EXT_INT_PIN and RTC_INT_PIN low will trigger a reset
+    if (ext_wakeup_triggered && shutdown_requested) {
+      reset_requested = true;
     }
 #endif
     // v_supercap is 10-bit while set_bar input is 16-bit - shift up by 6 bits

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -55,6 +55,7 @@ void sm_state_BEGIN() {
   gpio_poweroff_elapsed = 0;
   shutdown_requested = false;
   sleep_requested = false;
+  reset_requested = false;
 
   led_blinker.set_pattern(power_off_pattern);
 
@@ -310,6 +311,11 @@ void sm_state_SLEEP() {
 
 void sm_run() {
   static StateType last_state = BEGIN;
+  // Reset request overrides the state machine
+  if (reset_requested) {
+    reset_requested = false;
+    sm_state = ENT_OFF;
+  }
   if (last_state != sm_state) {
     Serial.print("New state: ");
     Serial.println(state_names[sm_state]);


### PR DESCRIPTION
New hardware version has functional Power/EXT header. Functionality has been re-enabled in firmware, and additional reset functionality has been added (pull both P and E pins to GND, and device will restart immediately).